### PR TITLE
Ensure Marktplaats bot flow returns PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,11 @@ curl -X POST "http://localhost:8000/generate/marktplaats" \
   -F "title=Test" \
   -F "price=10.00" \
   -F "url=https://example.com" \
-  -F "output=image" \
   -F "photo=@/path/to/photo.jpg" \
   -o marktplaats.png
-
-# Marktplaats — PDF (значение output можно опустить, по умолчанию pdf)
-curl -X POST "http://localhost:8000/generate/marktplaats" \
-  -H "X-API-Key: <ваш_ключ>" \
-  -F "title=Test" \
-  -F "price=10.00" \
-  -F "url=https://example.com" \
-  -F "photo=@/path/to/photo.jpg" \
-  -o marktplaats.pdf
 ```
+
+Эндпоинт Marktplaats больше не принимает параметр `output` и всегда возвращает PNG.
 
 -----------------------------------------------------------
 
@@ -110,7 +102,7 @@ app/handlers/qr.py
   - ask_photo(update, context) — Запрос фото
   - ask_url(update, context) — Запрос url
   соответствующие функции on_... сохраняют данные
-возвращает pdf
+возвращает PNG-файл
 
 -----------------------------------------------------------
 

--- a/app/api.py
+++ b/app/api.py
@@ -8,7 +8,7 @@ from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
 
 from app.services.apikey import get_all_keys
-from app.services.pdf import create_pdf, create_marktplaats_image
+from app.services.pdf import create_marktplaats_image
 from app.services.subito import create_subito_image, create_subito_pdf
 
 app = FastAPI(title="QR Generator API")
@@ -117,7 +117,6 @@ async def generate_marktplaats(
     title: str = Form(...),
     price: str = Form(...),
     url: str = Form(...),
-    output: str = Form("pdf"),
     photo: UploadFile | None = File(None),
     api_key: str = Depends(validate_api_key),
 ):
@@ -126,27 +125,7 @@ async def generate_marktplaats(
         photo_path = _save_upload(photo, tmp_dir)
         safe_url = _normalize_url(url)
 
-        mode = output.lower()
-        if mode not in {"image", "pdf"}:
-            raise HTTPException(status_code=400, detail="output must be 'image' or 'pdf'")
-
-        if mode == "image":
-            image_path, _, _ = create_marktplaats_image(
-                title,
-                price,
-                photo_path,
-                safe_url,
-                temp_dir=tmp_dir,
-            )
-            background = BackgroundTask(_cleanup_tmpdir, tmp_dir)
-            return FileResponse(
-                image_path,
-                media_type="image/png",
-                filename=os.path.basename(image_path),
-                background=background,
-            )
-
-        pdf_path, _, _ = create_pdf(
+        image_path, _, _ = create_marktplaats_image(
             title,
             price,
             photo_path,
@@ -155,9 +134,9 @@ async def generate_marktplaats(
         )
         background = BackgroundTask(_cleanup_tmpdir, tmp_dir)
         return FileResponse(
-            pdf_path,
-            media_type="application/pdf",
-            filename=os.path.basename(pdf_path),
+            image_path,
+            media_type="image/png",
+            filename=os.path.basename(image_path),
             background=background,
         )
     except HTTPException:


### PR DESCRIPTION
## Summary
- update the Marktplaats generation endpoint to always produce PNG responses
- ensure the Marktplaats Telegram bot flow sends the generated PNG instead of a PDF
- refresh the README instructions to reflect the PNG-only flow for Marktplaats

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ee46ab65148331b9beb97240f66615